### PR TITLE
Fix typo error.

### DIFF
--- a/src/ksana_llm/batch_scheduler/batch_scheduler_test.cpp
+++ b/src/ksana_llm/batch_scheduler/batch_scheduler_test.cpp
@@ -64,7 +64,7 @@ class BatchSchedulerTest : public testing::Test {
     cache_manager_config.block_token_num = block_manager_config.device_allocator_config.block_token_num;
     cache_manager_config.tensor_para_size = tp_num;
     cache_manager_config.swap_threadpool_size = 8;
-    cache_manager_config.enable_preifx_caching = false;
+    cache_manager_config.enable_prefix_caching = false;
   }
 
  protected:

--- a/src/ksana_llm/cache_manager/cache_manager_factory.cpp
+++ b/src/ksana_llm/cache_manager/cache_manager_factory.cpp
@@ -11,7 +11,7 @@ namespace ksana_llm {
 
 std::shared_ptr<CacheManagerInterface> CacheManagerFactory::CreateCacheManager(
     const CacheManagerConfig& cache_manager_config) {
-  if (cache_manager_config.enable_preifx_caching) {
+  if (cache_manager_config.enable_prefix_caching) {
     return std::make_shared<PrefixCacheManager>(cache_manager_config);
   } else {
     return std::make_shared<DirectCacheManager>(cache_manager_config);

--- a/src/ksana_llm/cache_manager/prefix_cache_manager_test.cpp
+++ b/src/ksana_llm/cache_manager/prefix_cache_manager_test.cpp
@@ -34,7 +34,7 @@ class PrefixCacheManagerTest : public testing::Test {
     cache_manager_config.block_token_num = 16;
     cache_manager_config.tensor_para_size = 2;
     cache_manager_config.swap_threadpool_size = 2;
-    cache_manager_config.enable_preifx_caching = true;
+    cache_manager_config.enable_prefix_caching = true;
 
     cache_manager = new PrefixCacheManager(cache_manager_config);
 

--- a/src/ksana_llm/models/common/common_model.cpp
+++ b/src/ksana_llm/models/common/common_model.cpp
@@ -29,7 +29,7 @@ template <typename T>
 void CommonModel<T>::InitRunConfig(const ModelRunConfig& model_run_config, std::shared_ptr<BaseWeight> base_weight) {
   GetBlockManager()->SetDeviceId(rank_);
 
-  preifx_caching_enabled_ = Singleton<Environment>::GetInstance()->IsPrefixCachingEnabled();
+  prefix_caching_enabled_ = Singleton<Environment>::GetInstance()->IsPrefixCachingEnabled();
 
   model_run_config_ = model_run_config;
 
@@ -332,7 +332,7 @@ Status CommonModel<T>::RemoveAttentionPrefixCache() {
 
 template <typename T>
 Status CommonModel<T>::FlashAttentionForward(const int layer_idx) {
-  bool reuse_prefix_caching = preifx_caching_enabled_;
+  bool reuse_prefix_caching = prefix_caching_enabled_;
 
   if (reuse_prefix_caching) {
     AddAttentionPrefixCache();

--- a/src/ksana_llm/models/common/common_model.h
+++ b/src/ksana_llm/models/common/common_model.h
@@ -78,7 +78,7 @@ class __attribute__((visibility("hidden"))) CommonModel : public BaseModel {
   using BaseModel::rank_;
 
   // Whether auto prefix caching is enabled.
-  bool preifx_caching_enabled_;
+  bool prefix_caching_enabled_;
 
   // The model config.
   ModelConfig model_config_;

--- a/src/ksana_llm/utils/environment.cpp
+++ b/src/ksana_llm/utils/environment.cpp
@@ -315,7 +315,7 @@ Status Environment::ParseConfig(const std::string &config_file) {
       yaml_reader.GetScalar<size_t>(yaml_reader.GetRootNode(), "setting.batch_scheduler.swap_threadpool_size", 2);
   cache_manager_config_.block_token_num = block_manager_config_.device_allocator_config.block_token_num;
   cache_manager_config_.tensor_para_size = tensor_parallel_size_;
-  cache_manager_config_.enable_preifx_caching =
+  cache_manager_config_.enable_prefix_caching =
       yaml_reader.GetScalar<bool>(yaml_reader.GetRootNode(), "setting.batch_scheduler.enable_auto_prefix_cache", false);
 
   // Read profiler config.
@@ -555,6 +555,6 @@ Status Environment::GetProfilerConfig(ProfilerConfig &profiler_config) {
   return Status();
 }
 
-bool Environment::IsPrefixCachingEnabled() { return cache_manager_config_.enable_preifx_caching; }
+bool Environment::IsPrefixCachingEnabled() { return cache_manager_config_.enable_prefix_caching; }
 
 }  // namespace ksana_llm

--- a/src/ksana_llm/utils/environment.h
+++ b/src/ksana_llm/utils/environment.h
@@ -189,7 +189,7 @@ struct CacheManagerConfig {
   size_t swap_threadpool_size = 2;
 
   // Whether enable prefix caching.
-  bool enable_preifx_caching = false;
+  bool enable_prefix_caching = false;
 };
 
 // The endpoint type.


### PR DESCRIPTION
change from `enable_preifx_caching`  to `enable_prefix_caching`.