### PR TITLE
Update kernel_wrapper.cpp

### DIFF
--- a/src/ksana_llm/kernels/nvidia/kernel_wrapper.cpp
+++ b/src/ksana_llm/kernels/nvidia/kernel_wrapper.cpp
@@ -1245,6 +1245,7 @@ void InvokePagedAttention(void* output_ptr, void* query_ptr, void** key_cache_pt
                     const_null_tensor,    // rotary_cos_: seqlen_ro x (rotary_dim / 2)
                     const_null_tensor,    // rotary_sin_: seqlen_ro x (rotary_dim / 2)
                     const_null_tensor,    // cache_batch_idx_: indices to index into the KV cache
+                    const_null_tensor,    // indices that the KV cache starts. [batch_size,], nullptr, default 0
                     block_table_tensor,   // batch_size x max_num_blocks_per_seq
                     alibi_slopes_tensor,  // num_heads or batch_size x num_heads
                     out_tensor,           // batch_size x seqlen_q x num_heads x head_size


### PR DESCRIPTION
Fix the issues that occur when running cmake -DSM=86 -DWITH_TESTING=ON .. && make -j32 for Ksana_llm error information：
/home/ubuntu/KsanaLLM/src/ksana_llm/kernels/nvidia/kernel_wrapper.cpp: In function ‘void ksana_llm::InvokePagedAttention(void*, void*, void**, void**, void*, int, cudaStream_t, void*, int, int, int, int, int, int, float, float, int, void*, void*, int, std::optional<llm_kernels::nvidia::RotaryEmbeddingCuda<SCALAR_T> >&, void*, float, bool, void*, void*, size_t, int, const std::optional<void*>&, void*, void*, void*, int32_t*, int64_t, int, bool, bool, bool, float, size_t)’:
/home/ubuntu/KsanaLLM/src/ksana_llm/kernels/nvidia/kernel_wrapper.cpp:1248:21: error: cannot bind non-const lvalue reference of type ‘std::optional<const at::Tensor>&’ to an rvalue of type ‘std::optional<const at::Tensor>’
 1248 |                     block_table_tensor,   // batch_size x max_num_blocks_per_seq
      |                     ^~~~~~~~~~~~~~~~~~
In file included from /usr/local/lib/python3.12/dist-packages/torch/include/c10/util/StringUtil.h:9:
/usr/include/c++/13/optional:768:9: note:   after user-defined conversion: ‘constexpr std::optional<_Tp>::optional(const std::optional<_Up>&) [with _Up = at::Tensor; typename std::enable_if<__and_v<std::__not_<std::is_same<_T1, _U1> >, std::is_constructible<_T1, const _U1&>, std::is_convertible<const _Up&, _Tp>, std::__not_<std::__or_<std::is_constructible<_Tp, const std::optional<_Up>&>, std::is_constructible<_Tp, std::optional<_Up>&>, std::is_constructible<_Tp, const std::optional<_Up>&&>, std::is_constructible<_Tp, std::optional<_Up>&&>, std::is_convertible<const std::optional<_Up>&, _Tp>, std::is_convertible<std::optional<_Up>&, _Tp>, std::is_convertible<const std::optional<_Up>&&, _Tp>, std::is_convertible<std::optional<_Up>&&, _Tp> > > >, bool>::type <anonymous> = true; _Tp = const at::Tensor]’

When the flash-attn version is 2.6.2, the function interfaces in src\ksana_llm\kernels\nvidia\kernel_wrapper.cpp do not correspond to those in ksana_llm/kernels/nvidia/flash_attn_cpp_wrapper.h.
